### PR TITLE
Create File Adalath demo portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# File Adalath - Online Portal
+
+This is a simple prototype of a file pendency tracking system built with core PHP and Bootstrap 5. The portal retrieves master data from the official File Adalath APIs and stores local status updates in MySQL.
+
+## Features
+- User login with roles: superadmin, deptadmin and sectionofficer
+- PROFORMA 1 interface to update file status
+- PROFORMA 2 summary report with export buttons
+- Remote API calls for departments, sections and files
+
+## Setup
+1. Import `database.sql` into a MySQL database and update `config/db.php` with credentials.
+2. Host the project in a PHP 8 environment.
+3. Access `login.php` and log in using credentials from the users table.
+
+The demo uses external APIs provided by the Government of Kerala to fetch department data. Only status updates are stored locally.

--- a/assets/js/proforma1.js
+++ b/assets/js/proforma1.js
@@ -1,17 +1,58 @@
-$(function() {
-    // Example: fetch department list, then files for department
-    $.getJSON('api/fetch_master_data.php?url=https://fileadalath.kerala.gov.in/api/department', function(departments) {
-        // Populate department dropdown, then fetch files etc.
+$(function () {
+    // populate department list
+    $.getJSON('api/fetch_master_data.php?url=https://fileadalath.kerala.gov.in/api/department?office_typeId=1', function (departments) {
+        var select = $('<select class="form-select mb-3" id="deptSelect"></select>');
+        select.append('<option value="">Select Department</option>');
+        $.each(departments, function (_, d) {
+            select.append(`<option value="${d.department_id}">${d.department_name}</option>`);
+        });
+        $('#fileTableContainer').before(select);
     });
 
-    // For inline status update (AJAX)
-    $(document).on('change', '.status-select', function() {
+    // when department selected load files
+    $(document).on('change', '#deptSelect', function () {
+        var deptId = $(this).val();
+        if (!deptId) return;
+        $('#fileTableContainer').html('<div class="text-center">Loading...</div>');
+        $.getJSON(`api/fetch_master_data.php?url=https://fileadhalath.kerala.gov.in/api/department-files/${deptId}`, function (files) {
+            var rows = '';
+            files.forEach(function (file, idx) {
+                rows += `<tr data-file-id="${file.id}">
+                    <td>${idx + 1}</td>
+                    <td>${file.section_name || ''}</td>
+                    <td>${file.year}</td>
+                    <td>${file.file_no} - ${file.subject}</td>
+                    <td><select class="form-select category-select" data-file-id="${file.id}"></select></td>
+                    <td><select class="form-select status-select"><option>Pending</option><option>Closed</option></select></td>
+                </tr>`;
+            });
+            var table = `<table class="table table-bordered">
+                <thead><tr><th>Sl.No</th><th>Section</th><th>Year</th><th>File & Subject</th><th>Category</th><th>Status</th></tr></thead>
+                <tbody>${rows}</tbody></table>`;
+            $('#fileTableContainer').html(table);
+            loadCategories();
+        });
+    });
+
+    function loadCategories() {
+        $.getJSON('api/fetch_master_data.php?url=https://fileadhalath.kerala.gov.in/api/department-category', function (cats) {
+            $('.category-select').each(function () {
+                var sel = $(this);
+                cats.forEach(function (c) {
+                    sel.append(`<option value="${c.id}">${c.category_name}</option>`);
+                });
+            });
+        });
+    }
+
+    // update status ajax
+    $(document).on('change', '.status-select', function () {
         var row = $(this).closest('tr');
         var fileId = row.data('file-id');
         var status = $(this).val();
-        $.post('update_status.php', {file_id: fileId, status: status}, function(res) {
+        $.post('update_status.php', {file_id: fileId, status: status}, function (res) {
             if (res.success) {
-                // Show toast/success
+                row.addClass('table-success');
             }
         }, 'json');
     });

--- a/assets/js/proforma2.js
+++ b/assets/js/proforma2.js
@@ -1,0 +1,14 @@
+$(function () {
+    // Fetch summary per department for super admin
+    $.getJSON('api/fetch_master_data.php?url=https://fileadalath.kerala.gov.in/api/department', function (departments) {
+        var cards = '';
+        departments.slice(0, 5).forEach(function (dept) { // limit to few for demo
+            cards += `<div class="col-md-4"><div class="card mb-3"><div class="card-body">
+                <h5 class="card-title">${dept.department_name}</h5>
+                <p class="card-text">Total Files: ...</p>
+                <div class="progress"><div class="progress-bar" style="width:50%">50%</div></div>
+            </div></div></div>`;
+        });
+        $('#summaryCards').html(cards);
+    });
+});

--- a/export.php
+++ b/export.php
@@ -1,0 +1,14 @@
+<?php
+require 'includes/auth.php';
+require 'config/db.php';
+$type = $_GET['type'] ?? 'excel';
+header('Content-Type: text/csv');
+header('Content-Disposition: attachment; filename="summary.csv"');
+$stmt = $pdo->query("SELECT department_id, COUNT(*) as total, SUM(status='Closed') as closed FROM file_status_updates GROUP BY department_id");
+$fp = fopen('php://output', 'w');
+fputcsv($fp, ['Department ID','Total','Closed']);
+while($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    fputcsv($fp, $row);
+}
+exit;
+?>


### PR DESCRIPTION
## Summary
- add README with setup instructions
- implement dynamic department and file loading in Proforma 1
- create simple summary cards in Proforma 2
- provide basic CSV export

## Testing
- `php -l login.php`
- `php -l dashboard.php`
- `php -l proforma1.php`
- `php -l proforma2.php`
- `php -l update_status.php`
- `php -l export.php`
- `php -l api/fetch_master_data.php`


------
https://chatgpt.com/codex/tasks/task_e_687cd17a620c832595c84b5416d8e75b