### PR TITLE
Add dashboard statistics and API update tools

### DIFF
--- a/api/update_data.php
+++ b/api/update_data.php
@@ -1,0 +1,27 @@
+<?php
+require '../includes/auth.php';
+header('Content-Type: application/json');
+$type = $_POST['type'] ?? '';
+$endpoints = [
+    'departments' => 'https://fileadalath.kerala.gov.in/api/department',
+    'categories'  => 'https://fileadalath.kerala.gov.in/api/department-category',
+    'files'       => 'https://fileadalath.kerala.gov.in/api/department-files'
+];
+if(!isset($endpoints[$type])) {
+    echo json_encode(['success'=>false,'error'=>'Invalid type']);
+    exit;
+}
+$target = __DIR__.'/../data/'.$type.'.json';
+$logFile = __DIR__.'/../data/update_log.json';
+$data = @file_get_contents($endpoints[$type]);
+if($data===false){
+    echo json_encode(['success'=>false,'error'=>'Fetch failed']);
+    exit;
+}
+file_put_contents($target,$data);
+$log = file_exists($logFile) ? json_decode(file_get_contents($logFile),true) : [];
+$time = date('Y-m-d H:i:s');
+$log[$type]=$time;
+file_put_contents($logFile,json_encode($log));
+echo json_encode(['success'=>true,'time'=>$time]);
+

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,26 +1,83 @@
-<?php require 'includes/auth.php'; ?>
+<?php
+require 'includes/auth.php';
+require 'config/db.php';
+
+$stats = $pdo->query("SELECT 
+    COUNT(*) as total,
+    SUM(status='Closed') as closed,
+    SUM(status='Pending') as pending,
+    COUNT(DISTINCT department_id) as departments,
+    COUNT(DISTINCT section_id) as sections
+ FROM file_status_updates")->fetch(PDO::FETCH_ASSOC);
+
+$logFile = __DIR__.'/data/update_log.json';
+$log = file_exists($logFile) ? json_decode(file_get_contents($logFile), true) : [];
+function last_time($key, $arr) { return $arr[$key] ?? 'Never'; }
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <title>Dashboard - File Adalath</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 </head>
 <body>
-<?php /* include 'includes/header.php'; */ ?>
 <div class="container mt-4">
     <h2>Welcome, <?= htmlspecialchars($user['name']) ?></h2>
-    <div class="row">
-        <!-- Dynamic cards based on user role -->
-        <?php if ($user['role'] == 'superadmin'): ?>
-            <!-- Fetch and display all departments summary here -->
-        <?php elseif ($user['role'] == 'deptadmin'): ?>
-            <!-- Section/seat-wise progress for department -->
-        <?php elseif ($user['role'] == 'sectionofficer'): ?>
-            <!-- Show only assigned section/seat files -->
-        <?php endif; ?>
+    <div class="d-flex justify-content-end mb-3">
+        <button class="btn btn-primary me-2 api-update-btn" data-type="departments">Update Departments</button>
+        <button class="btn btn-primary me-2 api-update-btn" data-type="categories">Update Categories</button>
+        <button class="btn btn-primary api-update-btn" data-type="files">Update Files</button>
+    </div>
+    <div class="row mb-4">
+        <div class="col-md-2">
+            <div class="card text-center"><div class="card-body"><h6>Total Updates</h6><p class="display-6"><?= $stats['total'] ?? 0 ?></p></div></div>
+        </div>
+        <div class="col-md-2">
+            <div class="card text-center"><div class="card-body"><h6>Closed</h6><p class="display-6"><?= $stats['closed'] ?? 0 ?></p></div></div>
+        </div>
+        <div class="col-md-2">
+            <div class="card text-center"><div class="card-body"><h6>Pending</h6><p class="display-6"><?= $stats['pending'] ?? 0 ?></p></div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="card text-center"><div class="card-body"><h6>Departments</h6><p class="display-6"><?= $stats['departments'] ?? 0 ?></p></div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="card text-center"><div class="card-body"><h6>Sections</h6><p class="display-6"><?= $stats['sections'] ?? 0 ?></p></div></div>
+        </div>
+    </div>
+    <div class="row" id="apiCards">
+        <?php foreach(['departments','categories','files'] as $t): ?>
+        <div class="col-md-4">
+            <div class="card mb-3 text-center">
+                <div class="card-body">
+                    <h5 class="card-title text-capitalize"><?= $t ?></h5>
+                    <button class="btn btn-sm btn-outline-primary api-update-btn" data-type="<?= $t ?>">Update</button>
+                    <p class="mt-2 mb-0"><small class="text-muted">Last updated: <span class="last-updated"><?= htmlspecialchars(last_time($t,$log)) ?></span></small></p>
+                </div>
+            </div>
+        </div>
+        <?php endforeach; ?>
     </div>
 </div>
+<script>
+$(function(){
+    $('.api-update-btn').click(function(){
+        var type = $(this).data('type');
+        var btn = $(this);
+        btn.prop('disabled', true).text('Updating...');
+        $.post('api/update_data.php', {type:type}, function(res){
+            if(res.success){
+                btn.closest('.card, .d-flex').find('.last-updated').text(res.time);
+            }else{
+                alert('Update failed');
+            }
+        }, 'json').always(function(){
+            btn.prop('disabled', false).text('Update '+type.charAt(0).toUpperCase()+type.slice(1));
+        });
+    });
+});
+</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show summarized statistics on the dashboard
- add API update buttons and last updated timestamps
- implement `api/update_data.php` to fetch master data
- track update files under `data/`

## Testing
- `php -l dashboard.php`
- `php -l api/update_data.php`


------
https://chatgpt.com/codex/tasks/task_e_687cd620cb148325ac1e99bb45ebb969