### PR TITLE
Improve API fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ This is a simple prototype of a file pendency tracking system built with core PH
    - **Password:** 123456
 
 The demo uses external APIs provided by the Government of Kerala to fetch department data. Only status updates are stored locally.
+
+### Updating master data
+
+After logging in, use the **Update** buttons on the dashboard to download the latest
+department, category and file lists from `fileadalath.kerala.gov.in`. The requests
+are proxied through the `api/` endpoints which now use cURL for improved
+compatibility.

--- a/api/fetch_master_data.php
+++ b/api/fetch_master_data.php
@@ -5,5 +5,19 @@ if (!$url || !preg_match('/^https:\/\/fileadalath\.kerala\.gov\.in\/api\//', $ur
     echo json_encode(['error' => 'Invalid URL']);
     exit;
 }
-echo file_get_contents($url);
+// Use cURL so the request has a user agent and better error handling
+$ch = curl_init($url);
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_USERAGENT => 'Filependency/1.0',
+    CURLOPT_FOLLOWLOCATION => true,
+]);
+$data = curl_exec($ch);
+if ($data === false) {
+    echo json_encode(['error' => curl_error($ch)]);
+    curl_close($ch);
+    exit;
+}
+curl_close($ch);
+echo $data;
 ?>

--- a/api/update_data.php
+++ b/api/update_data.php
@@ -13,11 +13,19 @@ if(!isset($endpoints[$type])) {
 }
 $target = __DIR__.'/../data/'.$type.'.json';
 $logFile = __DIR__.'/../data/update_log.json';
-$data = @file_get_contents($endpoints[$type]);
-if($data===false){
-    echo json_encode(['success'=>false,'error'=>'Fetch failed']);
+$ch = curl_init($endpoints[$type]);
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_USERAGENT => 'Filependency/1.0',
+    CURLOPT_FOLLOWLOCATION => true,
+]);
+$data = curl_exec($ch);
+if ($data === false) {
+    echo json_encode(['success'=>false,'error'=>curl_error($ch)]);
+    curl_close($ch);
     exit;
 }
+curl_close($ch);
 file_put_contents($target,$data);
 $log = file_exists($logFile) ? json_decode(file_get_contents($logFile),true) : [];
 $time = date('Y-m-d H:i:s');

--- a/assets/js/proforma1.js
+++ b/assets/js/proforma1.js
@@ -14,7 +14,7 @@ $(function () {
         var deptId = $(this).val();
         if (!deptId) return;
         $('#fileTableContainer').html('<div class="text-center">Loading...</div>');
-        $.getJSON(`api/fetch_master_data.php?url=https://fileadhalath.kerala.gov.in/api/department-files/${deptId}`, function (files) {
+        $.getJSON(`api/fetch_master_data.php?url=https://fileadalath.kerala.gov.in/api/department-files/${deptId}`, function (files) {
             var rows = '';
             files.forEach(function (file, idx) {
                 rows += `<tr data-file-id="${file.id}">
@@ -35,7 +35,7 @@ $(function () {
     });
 
     function loadCategories() {
-        $.getJSON('api/fetch_master_data.php?url=https://fileadhalath.kerala.gov.in/api/department-category', function (cats) {
+        $.getJSON('api/fetch_master_data.php?url=https://fileadalath.kerala.gov.in/api/department-category', function (cats) {
             $('.category-select').each(function () {
                 var sel = $(this);
                 cats.forEach(function (c) {


### PR DESCRIPTION
## Summary
- fix typos in API URLs
- use cURL in PHP proxy scripts
- document how to update master data

## Testing
- `php -l api/fetch_master_data.php`
- `php -l api/update_data.php`
- `php -l update_status.php`
- `php -l dashboard.php`
- `php -l login.php`
- `php -l proforma1.php`
- `php -l proforma2.php`


------
https://chatgpt.com/codex/tasks/task_e_687cd99cd50c832593432fd0c14dfa46